### PR TITLE
Don't read data from heap for zero HNID

### DIFF
--- a/pkg/property_context.go
+++ b/pkg/property_context.go
@@ -131,6 +131,11 @@ func (pstFile *File) GetPropertyContext(heapOnNode HeapOnNode, formatType string
 			propertyContextItem.IsExternalValueReference = true
 			break
 		default:
+			if referenceHNID == 0 {
+				// zero HNID means nil data for property
+				break
+			}
+
 			propertyContextItem.IsExternalValueReference = true
 
 			propertyNodeInputStream, err := pstFile.NewHeapOnNodeInputStreamFromHNID(referenceHNID, heapOnNode, []LocalDescriptor{}, formatType, encryptionType)


### PR DESCRIPTION
For string and binary properties if we receive HNID=0, we should not try to read data from heap.
HNID=0 means nil data or empty string.